### PR TITLE
Added a variable for additional server flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The browser opens automatically and you can preview the blog on your laptop or d
 Even if you run the easy-hugo-preview command many times, only one hugo process will run so do not mind it.
 Since the process of hugo running in the laptop or desktop disappears in 300 seconds, you do not have to worry about killing hugo process.
 
+    (setq easy-hugo-server-flags "-D")
+
+Set `easy-hugo-server-flags` to `-D` in order to preview drafts.
+
     M-x easy-hugo-publish
 
 You can publish your blog to the server and the browser opens automatically.

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -51,6 +51,11 @@
   :group 'easy-hugo
   :type 'string)
 
+(defcustom easy-hugo-server-flags ""
+  "Additional flags to pass to hugo server."
+  :group 'easy-hugo
+  :type 'string)
+
 (defcustom easy-hugo-preview-url "http://localhost:1313/"
   "Preview url of easy-hugo."
   :group 'easy-hugo
@@ -887,9 +892,9 @@ POST-FILE needs to have and extension '.md' or '.org' or '.ad' or '.rst' or '.mm
        (if (<= 0.25 (easy-hugo--version))
 	   (setq easy-hugo--server-process
 		 (start-process "hugo-server"
-				easy-hugo--preview-buffer easy-hugo-bin "server" "--navigateToChanged"))
+				easy-hugo--preview-buffer easy-hugo-bin "server" "--navigateToChanged" easy-hugo-server-flags))
 	 (setq easy-hugo--server-process
-	       (start-process "hugo-server" easy-hugo--preview-buffer easy-hugo-bin "server")))
+	       (start-process "hugo-server" easy-hugo--preview-buffer easy-hugo-bin "server" easy-hugo-server-flags)))
        (while easy-hugo--preview-loop
 	 (if (equal (easy-hugo--preview-status easy-hugo-preview-url) "200")
 	     (progn


### PR DESCRIPTION
The value of `easy-hugo-server-flags` will be passed as flags to the server process. It can be used to preview drafts, for example.