### PR TITLE
fix easy-hugo-mode don't get activated after call easy-hugo

### DIFF
--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -2453,14 +2453,15 @@ output directories whose names match REGEXP."
 	   (insert (concat (car lists) "\n"))
 	   (pop lists))
 	 (goto-char easy-hugo--cursor)
-	 (if easy-hugo--refresh
-	     (progn
-	       (when (< (line-number-at-pos) easy-hugo--unmovable-line)
-		 (goto-char (point-min))
-		 (forward-line (- easy-hugo--unmovable-line 1)))
-	       (beginning-of-line)
-	       (forward-char easy-hugo--forward-char))
-	   (forward-char easy-hugo--forward-char))
+	 (ignore-error
+         (if easy-hugo--refresh
+	         (progn
+	           (when (< (line-number-at-pos) easy-hugo--unmovable-line)
+		         (goto-char (point-min))
+		         (forward-line (- easy-hugo--unmovable-line 1)))
+	           (beginning-of-line)
+	           (forward-char easy-hugo--forward-char))
+	       (forward-char easy-hugo--forward-char)))
 	 (easy-hugo-mode)
 	 (when easy-hugo-emacspeak
 	   (easy-hugo-emacspeak-filename)))))))


### PR DESCRIPTION
I need to push easy-hugo-mode to `evil-emacs-state-modes` to get easy-hugo keybindings work. 

But easy-hugo-mode doesn't get activated after `M-x easy-hugo`. After debug the source code, I find the cause, `forward-char` will stop and signal error on reaching end or beginning of buffer. 
Maybe my solution is simple, but works for me, let me know if there is better way to do this.
