### PR TITLE
Org header categories field and minor fix

### DIFF
--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -878,7 +878,8 @@ Automatically select the deployment destination from init.el."
      "\n#+DATE: " datetimezone
      "\n#+PUBLISHDATE: " datetimezone
      "\n#+DRAFT: nil"
-     "\n#+TAGS[]: nil, nil"
+     "\n#+CATEGORIES[]: nil nil"
+     "\n#+TAGS[]: nil nil"
      "\n#+DESCRIPTION: Short description"
      "\n\n")))
 


### PR DESCRIPTION
Since it's a default Hugo field, it would be nice having Categories inside Org Header template.

Also removed commas between Tags values once it causes Hugo to misbehavior. Separating these values only with spaces should work fine.

(Tested it locally and it did ok)