### PR TITLE
Doc/readme-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # easy-hugo [![melpa badge][melpa-badge]][melpa-link] [![melpa stable badge][melpa-stable-badge]][melpa-stable-link] [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-![logo](image/logo.png)
+<p align="center"><img src="image/logo.png" alt="logo"></p>
 
-Emacs major mode for writing blogs made with hugo by markdown or org-mode or AsciiDoc or reStructuredText or mmark or html
+Emacs major mode designed for writing Hugo-powered blogs using various markup formats, including Markdown, Org-mode, AsciiDoc, reStructuredText, mmark, and HTML. It enhances the blogging experience within Emacs, making it easier to manage and create content.
 
 ## Screencast
 

--- a/README.md
+++ b/README.md
@@ -448,13 +448,14 @@ If you want to use org style header, set as below but you can not use M-x easy-h
 
 	(setq easy-hugo-org-header t)
 
-Then it becomes the following header.
+Then it becomes the following header. If you want to expand its keywords, use either ```#+KEY: VALUE``` format to set a single value string or ```#+KEY[]: VALUE_1 VALUE_2``` format to assign multiple values in a whitespace-separated list of strings.
 
      #+TITLE:  filename
      #+DATE:  2018-01-31T12:10:08-08:00
      #+PUBLISHDATE:  2018-01-31T12:10:08-08:00
      #+DRAFT: nil
-     #+TAGS: nil, nil
+     #+CATEGORIES[]: nil nil
+     #+TAGS[]: nil nil
      #+DESCRIPTION: Short description
 	 
 ## Multiple blogs setting

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Setting the picture directory of your laptop or desktop, it is easy to execute M
 
 	(setq easy-hugo-default-picture-directory "~/Pictures")
 
-If you want to use org style header, set as below but you can not use M-x easy-hugo-list-draft with this setting.
+If you want to use org style header, set it as below.
 
 	(setq easy-hugo-org-header t)
 


### PR DESCRIPTION
Hey there @masasam,

While revisiting the package and Hugo documentation to find a way to implement featured post images, I came up with some `README` modifications listed at the end.

Rather than introducing an images field into the org template, as we did for categories in #73, which was a good default, I wrote a brief explanation on how to include custom front matter fields/keywords for `easy-hugo-org-header` users, based on Front Matter [docs](https://gohugo.io/content-management/front-matter/). I think this approach makes more sense this time since the images field wouldn't be a sane default for the template, due its narrow use case and its dissonance from other templates fields in the repo. 

The `easy-hugo-list-draft` is working fine with the `easy-hugo-org-header`  set, so I removed a statement on that. Optionally, I also did some changes in the `intro` of the README, centering the logo and restructuring the synopsis---not sure if these were desired, so feel free to edit or drop them completely. 

TLDR:
- added a front matter howto to easy-hugo-org-header users
- removed a false positive feature absence/conflict
- introduced some changes to the readme intro (at your discretion)



_(My very first PR on GitHub was on this repo and you kindly welcomed it even though I was a newcomer. That encouraged me to learn more and contribute to open-source projects that I use. So thank you for your time and dedication to this package. I was happy to see it featured in the Hugo documentation.)_