### PR TITLE
Implement 'sort publishday' support for org-header

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,6 @@ Then it becomes the following header. If you want to expand its keywords, use ei
 
      #+TITLE:  filename
      #+DATE:  2018-01-31T12:10:08-08:00
-     #+PUBLISHDATE:  2018-01-31T12:10:08-08:00
      #+DRAFT: nil
      #+CATEGORIES[]: nil nil
      #+TAGS[]: nil nil

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -876,7 +876,6 @@ Automatically select the deployment destination from init.el."
     (concat
      "#+TITLE: " file
      "\n#+DATE: " datetimezone
-     "\n#+PUBLISHDATE: " datetimezone
      "\n#+DRAFT: nil"
      "\n#+CATEGORIES[]: nil nil"
      "\n#+TAGS[]: nil nil"

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -1667,7 +1667,7 @@ L .. Firebase timer   S .. Sort time     M .. Magit status     ? .. Describe-mod
       (save-match-data
 	(let ((pos 0)
 	      matches)
-	  (while (string-match "^[D\\|d]ate[:]? [=]?+[ ]*\\(.+?\\)$" source pos)
+	  (while (string-match "^[#]?[+]?[Dd][Aa][Tt][Ee][:]? [=]?+[ ]*\\(.+?\\)$" source pos)
 	    (push (match-string 1 source) matches)
 	    (setq pos (match-end 0)))
 	  (when matches
@@ -1707,7 +1707,7 @@ L .. Firebase timer   S .. Sort time     M .. Magit status     ? .. Describe-mod
 	(save-match-data
 	  (let ((pos 0)
 		matches)
-	    (while (string-match "^[D\\|d]ate[:]? [=]?+[ ]*\\(.+?\\)$" source pos)
+	    (while (string-match "^[#]?[+]?[Dd][Aa][Tt][Ee][:]? [=]?+[ ]*\\(.+?\\)$" source pos)
 	      (push (match-string 1 source) matches)
 	      (setq pos (match-end 0)))
 	    (when matches


### PR DESCRIPTION
Hi @masasam.

Currently, `sort publishday` feature doesn't work with `easy-hugo-org-header`.

This PR suggests adding support for that by extending the initial part of the regex inside  `easy-hugo--publishday-alist` and `easy-hugo--draft-publishday-alist` functions.

Basically, these changes optionally match the org-header `#+DATE:` field, while maintaining the previous matches.

I'm also suggesting removing the `#+PUBLISHDATE` field from the org template, since the `#+DATE` field takes precedence over it when both are set.

This way the org-header will have the same fields as the other archetypes. Additionally, we prevent any possible confusion with the `sort publishday` feature as well, which works through the date field.

Tested locally and worked fine :+1: 