### PR TITLE
Implement support for the newest configuration files basename convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Then it becomes the following header. If you want to expand its keywords, use ei
      #+CATEGORIES[]: nil nil
      #+TAGS[]: nil nil
      #+DESCRIPTION: Short description
-	 
+
 ## Multiple blogs setting
 
 When you change setting, you need to restart emacs.
@@ -564,7 +564,7 @@ See https://gohugo.io/overview/quickstart/
 
 ### Configuration file example
 
-config.toml
+hugo.toml
 
 	hasCJKLanguage = true
 	theme="material-design"

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -1386,13 +1386,14 @@ to the server."
   "Open Hugo's config file."
   (interactive)
   (easy-hugo-with-env
-   (cond ((file-exists-p (expand-file-name "config.toml" easy-hugo-basedir))
-	  (find-file (expand-file-name "config.toml" easy-hugo-basedir)))
-	 ((file-exists-p (expand-file-name "config.yaml" easy-hugo-basedir))
-	  (find-file (expand-file-name "config.yaml" easy-hugo-basedir)))
-	 ((file-exists-p (expand-file-name "config.json" easy-hugo-basedir))
-	  (find-file (expand-file-name "config.json" easy-hugo-basedir)))
-	 (t (error "Hugo config file not found at %s" easy-hugo-basedir)))))
+   (let ((config-files '("config.toml" "config.yaml" "config.json"
+                          "hugo.toml" "hugo.yaml" "hugo.json")))
+     (dolist (file config-files)
+       (let ((full-path (expand-file-name file easy-hugo-basedir)))
+         (when (file-exists-p full-path)
+           (find-file full-path)
+           (return))))
+     (error "No Hugo config file found in %s" easy-hugo-basedir))))
 
 (defcustom easy-hugo-help
   (if (null easy-hugo-sort-default-char)


### PR DESCRIPTION
From v0.109.0 on, Hugo started using `hugo` as basename for its configuration files (https://gohugo.io/getting-started/configuration/#configuration-file).

I've updated the `easy-hugo-open-config ` function to support this new naming convention along with the old one. 

Tested locally with both basenames and worked fine. 