### PR TITLE
Add customizable display option for deployment output buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,14 @@ If you deploy your blog at github etc.
 
 	M-x easy-hugo-github-deploy
 
-Execute deploy.sh which exists in directory `easy-hugo-basedir`.
+Execute deploy.sh which should be located in the directory `easy-hugo-basedir`.
 It is useful for hosting on [GitHub Pages](https://gohugo.io/tutorials/github-pages-blog/) etc.
 When you create deploy.sh with reference to [hosting](https://gohugo.io/hosting-and-deployment/),
 it can also correspond to various sites.
+If you set the variable `easy-hugo-github-deploy-display-buffer` to a non-nil value, the deployment output will be displayed in the `*hugo-github-deploy*` buffer during execution.
+
+    (setq easy-hugo-github-deploy-display-buffer t)
+
 For more GitHub Pages information refer to [here](https://github.com/masasam/emacs-easy-hugo/issues/27) and [here](https://github.com/masasam/emacs-easy-hugo/issues/75).
 If you use .github/workflows/hugo.yaml, GitHub Actions will work, so you don't need deploy.sh.
 

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -162,6 +162,13 @@ The default is drwxr-xr-x."
   :group 'easy-hugo
   :type 'string)
 
+(defcustom easy-hugo-github-deploy-display-buffer nil
+  "GitHub deployment output.
+If non-nil, the script output will be displayed in the
+*hugo-github-deploy* buffer during execution."
+  :group 'easy-hugo
+  :type 'boolean)
+
 (defcustom easy-hugo-markdown-extension "md"
   "Markdown extension.
 Please select md or markdown or mdown.
@@ -1133,23 +1140,45 @@ to the server."
 
 ;;;###autoload
 (defun easy-hugo-github-deploy ()
-  "Execute `easy-hugo-github-deploy-script' script locate at `easy-hugo-basedir'."
+  "Execute `easy-hugo-github-deploy-script' script located at `easy-hugo-basedir'.
+If `easy-hugo-github-deploy-display-buffer' is non-nil, display
+the deployment buffer during execution."
   (interactive)
   (easy-hugo-with-env
    (let ((deployscript (file-truename (expand-file-name
 				       easy-hugo-github-deploy-script
-				       easy-hugo-basedir))))
+				       easy-hugo-basedir)))
+	 (deploy-buffer "*hugo-github-deploy*"))
      (unless (executable-find deployscript)
-       (error "%s do not execute" deployscript))
-     (let ((ret (call-process deployscript nil "*hugo-github-deploy*" t)))
-       (unless (zerop ret)
-	 (switch-to-buffer (get-buffer "*hugo-github-deploy*"))
-	 (error "%s command does not end normally" deployscript)))
-     (when (get-buffer "*hugo-github-deploy*")
-       (kill-buffer "*hugo-github-deploy*"))
-     (message "Blog deployed")
-     (when easy-hugo-url
-       (browse-url easy-hugo-url)))))
+       (error "%s is not executable" deployscript))
+     (when (get-buffer deploy-buffer)
+       (kill-buffer deploy-buffer))
+     ;; Ensure a previous `deploy-buffer' is not open before starting.
+     (let ((deploy-buffer (get-buffer-create deploy-buffer))
+	   (inhibit-read-only t))
+       (with-current-buffer deploy-buffer
+	 (setq-local view-exit-action #'kill-buffer)
+	 (view-mode 1)
+	 (when (zerop (buffer-size))
+	   (insert "-*- " (substring (buffer-name) 1 -1)
+		   ": " deployscript " -*-\n")
+	   (insert (format "Deployment started at %s\n\n"
+			   (substring (current-time-string) 0 19))))
+	 (when easy-hugo-github-deploy-display-buffer
+	   (switch-to-buffer deploy-buffer))
+	 (let ((ret (call-process deployscript nil deploy-buffer t)))
+	   (unless (zerop ret)
+	     (switch-to-buffer deploy-buffer)
+	     (insert (format "\nDeployment exited abnormally with code %d at %s\n"
+			     ret (substring (current-time-string) 0 19)))
+	     (error "%s command exited abnormally" deployscript)))
+	 (insert (format "\nDeployment finished at %s\n"
+			 (substring (current-time-string) 0 19))))
+       (unless easy-hugo-github-deploy-display-buffer
+	 (kill-buffer deploy-buffer))
+       (message "Blog deployed")
+       (when easy-hugo-url
+	 (browse-url easy-hugo-url))))))
 
 ;;;###autoload
 (defun easy-hugo-github-deploy-timer (n)

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -1160,8 +1160,8 @@ the deployment buffer during execution."
 	 (setq-local view-exit-action #'kill-buffer)
 	 (view-mode 1)
 	 (when (zerop (buffer-size))
-	   (insert "-*- " (substring (buffer-name) 1 -1)
-		   ": " deployscript " -*-\n")
+	   (insert "*** " (substring (buffer-name) 1 -1)
+		   ": " deployscript " ***\n")
 	   (insert (format "Deployment started at %s\n\n"
 			   (substring (current-time-string) 0 19))))
 	 (when easy-hugo-github-deploy-display-buffer


### PR DESCRIPTION
Since I run some binaries in my `deploy.sh` to hit APIs, I often need to check the script output for every deployment. I was using `tee` to manually check the logs, but I thought this could be a nice feature to add upstream.

TLDR:
This PR implements a customizable variable, `easy-hugo-github-deploy-display-buffer`, to display the deployment buffer output for `easy-hugo-github-deploy` in real time. The default value is `nil`, so this change should be seamless for users who don’t enable it.

Main changes:

- Enabled `view-mode` to make the buffer read-only and provide the `q` binding to kill the buffer (as easy-hugo does).
- Set `inhibit-read-only` to allow the script/code scope to write to the read-only buffer. [Reference](https://www.gnu.org/software/emacs/manual/html_node/elisp/Read-Only-Buffers.html).
- Added "header" and "footer" lines to encapsulate the script output (inspired by the compilation buffer).
- Used `switch-to-buffer` to open the buffer in the current window. You can change this to `pop-to-buffer` if you prefer.

Tested the changes locally, trough `easy-hugo-github-deploy` and `easy-hugo-publish-clever`, and everything *seems* to be working fine :smile:

Here is an ephemeral real output example testing the changes (link expire in 7 days due irrelevance/privacy): https://0x0.st/8zYD.txt

*Happy new year btw, @masasam!* 
