### PR TITLE
Add support for custom org archetypes and front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,18 +448,19 @@ Setting the picture directory of your laptop or desktop, it is easy to execute M
 
 	(setq easy-hugo-default-picture-directory "~/Pictures")
 
-If you want to use org style header, set it as below.
+To use an org-style header, create an `archetypes/default.org` file in your root directory as shown below:
 
-	(setq easy-hugo-org-header t)
+```
+#+TITLE: {{ replace .File.ContentBaseName "-" " " | title }}
+#+DATE: {{ .Date }}
+#+DRAFT: t
+#+CATEGORIES[]:
+#+TAGS[]:
+```
 
-Then it becomes the following header. If you want to expand its keywords, use either ```#+KEY: VALUE``` format to set a single value string or ```#+KEY[]: VALUE_1 VALUE_2``` format to assign multiple values in a whitespace-separated list of strings.
-
-     #+TITLE:  filename
-     #+DATE:  2018-01-31T12:10:08-08:00
-     #+DRAFT: nil
-     #+CATEGORIES[]: nil nil
-     #+TAGS[]: nil nil
-     #+DESCRIPTION: Short description
+You can then use the `easy-hugo-newpost` command (`n`) to create new `.org` posts with this template.
+Custom archetypes for other content types and front matter formats are also supported.
+For more information, see the official documentation on [archetypes](https://gohugo.io/content-management/archetypes/).
 
 ## Multiple blogs setting
 

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -220,11 +220,6 @@ Because only two are supported by hugo."
   :group 'easy-hugo
   :type 'integer)
 
-(defcustom easy-hugo-org-header nil
-  "Flg of use in org format header with hugo version 0.25 and above."
-  :group 'easy-hugo
-  :type 'integer)
-
 (defvar easy-hugo--preview-loop t
   "Preview loop flg.")
 
@@ -893,32 +888,18 @@ Automatically select the deployment destination from init.el."
       (browse-url (easy-hugo-nth-eval-bloglist easy-hugo-url n)))
     (setf (nth n easy-hugo--firebase-deploy-timer-list) nil)))
 
-(defun easy-hugo--org-headers (file)
-  "Return a draft org mode header string for a new article as FILE."
-  (let ((datetimezone
-         (concat
-          (format-time-string "%Y-%m-%dT%T")
-          (easy-hugo--orgtime-format (format-time-string "%z")))))
-    (concat
-     "#+TITLE: " file
-     "\n#+DATE: " datetimezone
-     "\n#+DRAFT: nil"
-     "\n#+CATEGORIES[]: nil nil"
-     "\n#+TAGS[]: nil nil"
-     "\n#+DESCRIPTION: Short description"
-     "\n\n")))
 
 ;;;###autoload
 (defun easy-hugo-newpost (post-file)
   "Create a new post with hugo.
-POST-FILE needs to have and extension '.md' or '.org' or '.ad' or
-'.rst' or '.mmark' or '.html'."
+POST-FILE needs to have an extension '.md', '.org', '.ad', '.rst',
+'.mmark', or '.html'."
   (interactive (list (read-from-minibuffer
-		      "Filename: "
-		      `(,easy-hugo-default-ext . 1) nil nil nil)))
+                      "Filename: "
+                      `(,easy-hugo-default-ext . 1) nil nil nil)))
   (easy-hugo-with-env
    (let ((filename (expand-file-name post-file easy-hugo-postdir))
-	 (file-ext (file-name-extension post-file)))
+         (file-ext (file-name-extension post-file)))
      (when (not (member file-ext easy-hugo--formats))
        (error "Please enter .%s, .%s, .%s, .%s, .%s, or .%s file name"
               easy-hugo-markdown-extension
@@ -929,25 +910,13 @@ POST-FILE needs to have and extension '.md' or '.org' or '.ad' or
               easy-hugo-html-extension))
      (when (file-exists-p (file-truename filename))
        (error "%s already exists!" filename))
-     (if (null easy-hugo-org-header)
-	 (call-process easy-hugo-bin nil "*hugo*" t "new"
-		       (file-relative-name filename
-					   (expand-file-name "content" easy-hugo-basedir)))
-       (progn
-	 (if (or (string-equal file-ext easy-hugo-markdown-extension)
-		 (string-equal file-ext easy-hugo-asciidoc-extension)
-		 (string-equal file-ext "rst")
-		 (string-equal file-ext "mmark")
-		 (string-equal file-ext easy-hugo-html-extension))
-	     (call-process easy-hugo-bin nil "*hugo*" t "new"
-			   (file-relative-name filename
-					       (expand-file-name "content" easy-hugo-basedir))))))
+     (call-process
+      easy-hugo-bin nil "*hugo*" t "new"
+      (file-relative-name filename
+                          (expand-file-name "content" easy-hugo-basedir)))
      (when (get-buffer "*hugo*")
        (kill-buffer "*hugo*"))
      (find-file filename)
-     (when (and easy-hugo-org-header
-	       (string-equal file-ext "org"))
-       (insert (easy-hugo--org-headers (file-name-base post-file))))
      (goto-char (point-max))
      (save-buffer))))
 

--- a/easy-hugo.el
+++ b/easy-hugo.el
@@ -255,12 +255,21 @@ Because only two are supported by hugo."
 (defconst easy-hugo--preview-buffer "*Hugo Preview*"
   "Easy-hugo preview buffer name.")
 
+(defconst easy-hugo--org-extension "org"
+  "Default org extension value, only supported variant.")
+
+(defconst easy-hugo--rst-extension "rst"
+  "Default rst extension value, only supported variant.")
+
+(defconst easy-hugo--mmark-extension "mmark"
+  "Default mmark extension value, only supported variant.")
+
 (defconst easy-hugo--formats `(,easy-hugo-markdown-extension
-			       "org"
-			       ,easy-hugo-asciidoc-extension
-			       "rst"
-			       "mmark"
-			       ,easy-hugo-html-extension))
+			                   ,easy-hugo--org-extension
+			                   ,easy-hugo-asciidoc-extension
+			                   ,easy-hugo--rst-extension
+			                   ,easy-hugo--mmark-extension
+			                   ,easy-hugo-html-extension))
 
 (defface easy-hugo-help-face
   `((((class color) (background light))
@@ -911,10 +920,13 @@ POST-FILE needs to have and extension '.md' or '.org' or '.ad' or
    (let ((filename (expand-file-name post-file easy-hugo-postdir))
 	 (file-ext (file-name-extension post-file)))
      (when (not (member file-ext easy-hugo--formats))
-       (error "Please enter .%s or .org or .%s or .rst or .mmark or .%s file name"
-	      easy-hugo-markdown-extension
-	      easy-hugo-asciidoc-extension
-	      easy-hugo-html-extension))
+       (error "Please enter .%s, .%s, .%s, .%s, .%s, or .%s file name"
+              easy-hugo-markdown-extension
+              easy-hugo--org-extension
+              easy-hugo-asciidoc-extension
+              easy-hugo--rst-extension
+              easy-hugo--mmark-extension
+              easy-hugo-html-extension))
      (when (file-exists-p (file-truename filename))
        (error "%s already exists!" filename))
      (if (null easy-hugo-org-header)
@@ -1830,8 +1842,13 @@ Optional prefix ARG says how many lines to move; default is one line."
    (let ((newname (expand-file-name post-file easy-hugo-postdir))
 	 (file-ext (file-name-extension post-file)))
      (when (not (member file-ext easy-hugo--formats))
-       (error "Please enter .%s or .org or .%s or .rst or .mmark or .%s file name"
-	      easy-hugo-markdown-extension easy-hugo-asciidoc-extension easy-hugo-html-extension))
+       (error "Please enter .%s, .%s, .%s, .%s, .%s, or .%s file name"
+	      easy-hugo-markdown-extension
+          easy-hugo--org-extension
+          easy-hugo-asciidoc-extension
+          easy-hugo--rst-extension
+          easy-hugo--mmark-extension
+          easy-hugo-html-extension))
      (when (equal (buffer-name (current-buffer)) easy-hugo--buffer-name)
        (when (file-exists-p (file-truename newname))
 	 (error "%s already exists!" newname))


### PR DESCRIPTION
While creating some archetypes, I noticed that Hugo's templating system handles archetypes with `.org` extension/header just fine[1] (e.g., `archetypes/default.org` or `archetypes/projects.org`):

https://gohugo.io/content-management/archetypes/

This removes the need for the hard-coded header insertion via `easy-hugo-org-header`, letting Hugo itself handle it through archetypes and enabling user customization. (The logic for other formats in the `easy-hugo-newpost` function already works this way).

Since Hugo has a built-in fallback archetype[2], current users of `easy-hugo-org-header` might only notice a change in the generated front matter if they don't have an `archetypes/default.org` file (meaning, the front matter will be generated in Hugo's fallback format[3] instead of Org format). I added an Org archetype example to the README to provide some guidance for them.

The only reason I'm not proposing this as opt-in is that I believe it's a good default for `easy-hugo-org-header` users. I've also tested Hugo's built-in fallback archetype with `.org` posts, and it worked fine.

Main changes (406f08e):

- Remove the `easy-hugo-org-header` custom variable and related logic.
- Remove the `easy-hugo--org-headers` function and related logic.
- Use Hugo's built-in archetype mechanism/lookup for new posts.
- Simplify conditional checks in the `newpost` function.

Regarding the validation/conditional checks, I removed some of them from the `call-process` scope since I considered the `(not (member file-ext easy-hugo--formats))` sufficient.

Minor changes (3dc8b48):

- Replace "org", "rst", and "mmark" with internal constants.

[1] I added a complete example to the README for reference.

[2] "If none of these exists, Hugo uses a built-in default archetype." https://gohugo.io/content-management/archetypes/#lookup-order

[3] https://github.com/gohugoio/hugo/blob/fe64a682254e32391a6d0c78f277b1133e1f4583/create/content.go#L41

_P.S.: A bit early, but happy new year once again, @masasam. Hopefully, my next PR won't be at the end of the year again :sweat_smile:_
